### PR TITLE
feat(terraform): switch to prebuilt zeroclaw ghcr runtime image

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ This repository manages **6 self-hosted services** on my Synology NAS.
 | `infra-db`       | `adminer`  | `adminer`                        | `adminer:5.3.0`                         |
 | `infra-db`       | `postgres` | `bitnamilegacy/postgresql`       | `bitnamilegacy/postgresql:17.5.0`       |
 | `n8n`            | `n8n`      | `n8nio/n8n`                      | `n8nio/n8n:2.1.5-amd64`                 |
-| `zeroclaw-cyrus` | `zeroclaw` | `ghcr.io/zeroclaw-labs/zeroclaw` | `ghcr.io/zeroclaw-labs/zeroclaw:v0.6.8` |
-| `zeroclaw-lior`  | `zeroclaw` | `ghcr.io/zeroclaw-labs/zeroclaw` | `ghcr.io/zeroclaw-labs/zeroclaw:v0.6.8` |
+| `zeroclaw-cyrus` | `zeroclaw` | `ghcr.io/ccamel/zeroclaw-runtime` | `ghcr.io/ccamel/zeroclaw-runtime:v0.6.8-ubuntu24.04` |
+| `zeroclaw-lior`  | `zeroclaw` | `ghcr.io/ccamel/zeroclaw-runtime` | `ghcr.io/ccamel/zeroclaw-runtime:v0.6.8-ubuntu24.04` |
 
 ### Platform Building Blocks
 
 - Infrastructure state is managed by `Terraform` via `synology-community/synology` (~> 0.4).
 - Runtime is organized as Synology Container Manager projects with bind-mounted DSM folders for persistence.
+- ZeroClaw uses a prebuilt Ubuntu-based runtime image published to GHCR; application state is persisted in `~/.zeroclaw`.
 - Declared runtime technologies: `adminer`, `deno`, `n8n`, `postgresql`, `zeroclaw`.
 - Declared runtime networks: `edge`, `infra`.
 <!-- END_DEPLOYED_OVERVIEW -->
@@ -65,6 +66,19 @@ Available recipes:
 ```
 
 <!-- END_JUST_RECIPES -->
+
+## ZeroClaw Runtime Image
+
+Docker images are defined under `docker/<image-name>/<image-tag>/Dockerfile` and published by [`.github/workflows/build-docker-images.yml`](.github/workflows/build-docker-images.yml).
+
+The current ZeroClaw runtime lives in [`docker/zeroclaw-runtime/v0.6.8-ubuntu24.04/Dockerfile`](docker/zeroclaw-runtime/v0.6.8-ubuntu24.04/Dockerfile).
+
+- The published image name is derived from `<image-name>` and the published tag from `<image-tag>`.
+- The workflow discovers changed Docker build contexts and builds them through a matrix job.
+- Optional `.platforms` and `.build-args` files next to a Dockerfile control per-image settings.
+- Terraform should reference a versioned tag, not `latest`.
+- A Synology NAS can pull the image anonymously only if the GHCR package is marked `public`.
+- If the package stays `private`, Container Manager must authenticate to `ghcr.io` with a GitHub token that has `read:packages`.
 
 ## Terraform Details
 
@@ -121,7 +135,7 @@ Available recipes:
 | <a name="input_n8n_webhook_url"></a> [n8n_webhook_url](#input_n8n_webhook_url)                                              | Public URL for n8n webhooks                                                                                         | `string` | `"localhost:5678"`                        |    no    |
 | <a name="input_postgres_password"></a> [postgres_password](#input_postgres_password)                                        | Password for the PostgreSQL service                                                                                 | `string` | `"postgres-password"`                     |    no    |
 | <a name="input_postgres_user"></a> [postgres_user](#input_postgres_user)                                                    | Username for the PostgreSQL service                                                                                 | `string` | `"postgres-user"`                         |    no    |
-| <a name="input_zeroclaw_image"></a> [zeroclaw_image](#input_zeroclaw_image)                                                 | ZeroClaw container image. Use the upstream :debian variant if the default image has runtime issues on your Synology | `string` | `"ghcr.io/zeroclaw-labs/zeroclaw:v0.6.8"` |    no    |
+| <a name="input_zeroclaw_image"></a> [zeroclaw_image](#input_zeroclaw_image)                                                 | Prebuilt ZeroClaw runtime image published to GHCR | `string` | `"ghcr.io/ccamel/zeroclaw-runtime:v0.6.8-ubuntu24.04"` |    no    |
 
 ## Outputs
 

--- a/modules/zeroclaw/main.tf
+++ b/modules/zeroclaw/main.tf
@@ -25,47 +25,17 @@ resource "synology_container_project" "this" {
   share_path = "${var.projects_root}/${local.project_name}"
 
   services = {
-    permfix = {
-      image = "alpine:3.22"
-      user  = "0:0"
-      name  = "${local.project_name}-permfix"
-
-      volumes = [{
-        type      = "bind"
-        source    = "./data"
-        target    = "/fix"
-        bind      = { create_host_path = true }
-        read_only = false
-      }]
-
-      entrypoint = ["sh", "-lc"]
-      command = [
-        "chown -R 65534:65534 /fix && chmod 755 /fix && echo OK"
-      ]
-
-      restart = "no"
-
-      healthcheck = {
-        test         = ["CMD-SHELL", "[ -f /bin/true ] || exit 1"]
-        interval     = "10s"
-        timeout      = "2s"
-        retries      = 1
-        start_period = "1s"
-      }
-
-      logging = { driver = "json-file" }
-    }
-
     zeroclaw = {
       image = var.image
       name  = local.project_name
 
       command = [
+        "zeroclaw",
         "daemon",
         "--host",
         "0.0.0.0",
         "--port",
-        "42617"
+        "42617",
       ]
 
       ports = [{
@@ -76,7 +46,7 @@ resource "synology_container_project" "this" {
       volumes = [{
         type      = "bind"
         source    = "./data"
-        target    = "/zeroclaw-data"
+        target    = "/root/.zeroclaw"
         bind      = { create_host_path = true }
         read_only = false
       }]
@@ -93,10 +63,6 @@ resource "synology_container_project" "this" {
 
       networks = {
         edge_net = {}
-      }
-
-      depends_on = {
-        permfix = { condition = "service_completed_successfully" }
       }
 
       logging = { driver = "json-file" }

--- a/modules/zeroclaw/variables.tf
+++ b/modules/zeroclaw/variables.tf
@@ -14,7 +14,7 @@ variable "published_port" {
 }
 
 variable "image" {
-  description = "ZeroClaw container image"
+  description = "ZeroClaw runtime image"
   type        = string
 }
 

--- a/zeroclaw.variables.tf
+++ b/zeroclaw.variables.tf
@@ -1,5 +1,5 @@
 variable "zeroclaw_image" {
-  description = "ZeroClaw container image. Use the upstream :debian variant if the default image has runtime issues on your Synology"
+  description = "Prebuilt ZeroClaw runtime image published to GHCR"
   type        = string
-  default     = "ghcr.io/zeroclaw-labs/zeroclaw:v0.6.8"
+  default     = "ghcr.io/ccamel/zeroclaw-runtime:v0.6.8-ubuntu24.04"
 }


### PR DESCRIPTION
Expands [Zeroclaw](https://zeroclawlabs.ai)'s runtime environment by switching to a custom [Ubuntu 24.04-based image](https://hub.docker.com/_/ubuntu), giving it greater flexibility and autonomy.