### PR TITLE
refactor(terraform): migrate synology runtime to ansible-managed docker compose

### DIFF
--- a/.github/workflows/build-terraform.yml
+++ b/.github/workflows/build-terraform.yml
@@ -33,6 +33,7 @@ jobs:
       TF_VAR_dsm_host: ${{ secrets.DSM_HOST }}
       TF_VAR_dsm_user: ${{ secrets.DSM_USER }}
       TF_VAR_dsm_password: ${{ secrets.DSM_PASSWORD }}
+      TF_VAR_deploy_ssh_private_key_path: /tmp/terraform-ci-dummy-key
       # -- bobine keys for build only --
       TF_VAR_bobine_ed25519_private_key_hex: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
       TF_VAR_bobine_ed25519_public_key_hex: '0000000000000000000000000000000000000000000000000000000000000000'

--- a/ansible/deploy-compose-stack.yml
+++ b/ansible/deploy-compose-stack.yml
@@ -1,0 +1,69 @@
+---
+- name: Deploy rendered Docker Compose stack
+  hosts: all
+  gather_facts: false
+  collections:
+    - community.docker
+  vars:
+    stack_spec: "{{ lookup('ansible.builtin.env', 'COMPOSE_STACK_SPEC_B64') | b64decode | from_json }}"
+
+  tasks:
+    - name: Ensure remote stack directory exists
+      ansible.builtin.file:
+        path: "{{ stack_spec.remote_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Upload compose.yaml
+      ansible.builtin.copy:
+        dest: "{{ stack_spec.remote_dir }}/compose.yaml"
+        content: "{{ stack_spec.compose_yaml }}"
+        mode: "0644"
+
+    - name: Upload .env
+      ansible.builtin.copy:
+        dest: "{{ stack_spec.remote_dir }}/.env"
+        content: "{{ stack_spec.env_file }}"
+        mode: "0600"
+      when: stack_spec.env_file | length > 0
+
+    - name: Remove .env when the stack does not use one
+      ansible.builtin.file:
+        path: "{{ stack_spec.remote_dir }}/.env"
+        state: absent
+      when: stack_spec.env_file | length == 0
+
+    - name: Upload stack companion files
+      ansible.builtin.copy:
+        dest: "{{ stack_spec.remote_dir }}/{{ item.path }}"
+        content: "{{ item.content }}"
+        mode: "{{ item.mode }}"
+      loop: "{{ stack_spec.extra_files }}"
+      loop_control:
+        label: "{{ item.path }}"
+
+    - name: Ensure required external Docker networks exist
+      ansible.builtin.shell: |
+        set -eu
+        if ! docker network inspect "{{ item.name }}" >/dev/null 2>&1; then
+          cmd="docker network create --driver bridge"
+          if [ "{{ item.internal | default(false) | ternary('true', 'false') }}" = "true" ]; then
+            cmd="$cmd --internal"
+          fi
+          cmd="$cmd {{ item.name }}"
+          sh -lc "$cmd"
+        fi
+      args:
+        executable: /bin/sh
+      loop: "{{ stack_spec.external_networks | default([]) }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Apply Compose stack
+      community.docker.docker_compose_v2:
+        project_name: "{{ stack_spec.project_name }}"
+        project_src: "{{ stack_spec.remote_dir }}"
+        files:
+          - compose.yaml
+        remove_orphans: true
+        state: present

--- a/ansible/destroy-compose-stack.yml
+++ b/ansible/destroy-compose-stack.yml
@@ -1,0 +1,24 @@
+---
+- name: Tear down rendered Docker Compose stack
+  hosts: all
+  gather_facts: false
+  collections:
+    - community.docker
+  vars:
+    stack_spec: "{{ lookup('ansible.builtin.env', 'COMPOSE_STACK_SPEC_B64') | b64decode | from_json }}"
+
+  tasks:
+    - name: Check whether compose.yaml exists remotely
+      ansible.builtin.stat:
+        path: "{{ stack_spec.remote_dir }}/compose.yaml"
+      register: compose_file
+
+    - name: Stop Compose stack when present
+      community.docker.docker_compose_v2:
+        project_name: "{{ stack_spec.project_name }}"
+        project_src: "{{ stack_spec.remote_dir }}"
+        files:
+          - compose.yaml
+        remove_orphans: true
+        state: absent
+      when: compose_file.stat.exists

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.docker

--- a/bobine.tf
+++ b/bobine.tf
@@ -7,126 +7,31 @@ resource "synology_filestation_folder" "bobine_local" {
   }
 }
 
-resource "synology_container_project" "bobine" {
-  name       = "bobine"
-  run        = true
-  share_path = "${var.dsm_volume_projects}/bobine"
+module "bobine" {
+  source = "./modules/compose_stack"
 
-  services = {
-    permfix = {
-      image = "alpine:3.22"
-      user  = "0:0"
-      name  = "bobine-permfix"
-
-      volumes = [{
-        type      = "bind"
-        source    = "./local"
-        target    = "/fix"
-        bind      = { create_host_path = true }
-        read_only = false
-      }]
-
-      entrypoint = ["sh", "-lc"]
-      command = [
-        "chown -R 1000:1000 /fix && chmod 755 /fix && echo OK"
-      ]
-
-      restart = "no"
-
-      healthcheck = {
-        test         = ["CMD-SHELL", "[ -f /bin/true ] || exit 1"]
-        interval     = "10s"
-        timeout      = "2s"
-        retries      = 1
-        start_period = "1s"
-      }
-
-      logging = { driver = "json-file" }
-    }
-
-    bobine = {
-      image = "denoland/deno:debian-2.6.3"
-      name  = "bobine-bobine"
-      user  = "1000:1000"
-
-      ports = [{
-        target    = 8080
-        published = var.bobine_published_port
-      }]
-
-      volumes = [{
-        type      = "bind"
-        source    = "./local"
-        target    = "/app/local"
-        bind      = { create_host_path = true }
-        read_only = false
-      }]
-
-      environment = {
-        DATABASE_PATH           = "./local/database.db"
-        SCRIPTS_PATH            = "./local/scripts"
-        ED25519_PRIVATE_KEY_HEX = var.bobine_ed25519_private_key_hex
-        ED25519_PUBLIC_KEY_HEX  = var.bobine_ed25519_public_key_hex
-      }
-
-      entrypoint = ["sh", "-lc"]
-      command = [<<-EOC
-        set -eu
-
-        export DENO_DIR="/app/local/deno-dir"
-        export DENO_INSTALL_ROOT="/app/local/deno-install"
-        export PATH="$$DENO_INSTALL_ROOT/bin:$$PATH"
-
-        mkdir -p "$$DENO_DIR" "$$DENO_INSTALL_ROOT" /app/local/scripts /tmp/bobine
-
-        if ! command -v bobine >/dev/null 2>&1; then
-          deno install --root "$$DENO_INSTALL_ROOT" -g -f -A npm:@hazae41/bobine
-        fi
-
-        printf "DATABASE_PATH=%s\nSCRIPTS_PATH=%s\nED25519_PRIVATE_KEY_HEX=%s\nED25519_PUBLIC_KEY_HEX=%s\n" \
-          "$$DATABASE_PATH" \
-          "$$SCRIPTS_PATH" \
-          "$$ED25519_PRIVATE_KEY_HEX" \
-          "$$ED25519_PUBLIC_KEY_HEX" \
-          > /tmp/bobine/.env
-
-        cd /app
-        exec bobine serve --env=/tmp/bobine/.env --port=8080 --dev
-      EOC
-      ]
-
-      healthcheck = {
-        test         = ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1"]
-        interval     = "30s"
-        timeout      = "10s"
-        retries      = 5
-        start_period = "30s"
-      }
-
-      restart = "unless-stopped"
-
-      networks = {
-        edge_net = {}
-      }
-
-      depends_on = {
-        permfix = { condition = "service_completed_successfully" }
-      }
-
-      logging = { driver = "json-file" }
-    }
-  }
-
-  networks = {
-    edge_net = {
-      attachable = true
-      driver     = "bridge"
-      name       = "edge"
-      external   = true
-    }
-  }
+  stack_name                   = "bobine"
+  project_name                 = "bobine"
+  remote_dir                   = dirname(synology_filestation_folder.bobine_local.real_path)
+  ssh_host                     = local.compose_deploy_ssh_host
+  ssh_user                     = local.compose_deploy_ssh_user
+  ssh_port                     = var.deploy_ssh_port
+  ssh_private_key_path         = var.deploy_ssh_private_key_path
+  ssh_strict_host_key_checking = var.deploy_ssh_strict_host_key_checking
+  compose_yaml                 = templatefile("${path.module}/templates/bobine.compose.yaml.tftpl", {})
+  external_networks = [
+    {
+      name     = "edge"
+      internal = false
+    },
+  ]
+  env_file = templatefile("${path.module}/templates/bobine.env.tftpl", {
+    bobine_published_port          = var.bobine_published_port
+    bobine_ed25519_private_key_hex = var.bobine_ed25519_private_key_hex
+    bobine_ed25519_public_key_hex  = var.bobine_ed25519_public_key_hex
+  })
 
   depends_on = [
-    synology_filestation_folder.bobine_local
+    synology_filestation_folder.bobine_local,
   ]
 }

--- a/infra-db.tf
+++ b/infra-db.tf
@@ -7,134 +7,35 @@ resource "synology_filestation_folder" "infra_db_pgdata" {
   }
 }
 
-resource "synology_container_project" "infra_db" {
-  name       = "infra-db"
-  run        = true
-  share_path = "${var.dsm_volume_projects}/infra-db"
+module "infra_db" {
+  source = "./modules/compose_stack"
 
-  services = {
-    permfix = {
-      image = "alpine:3.22"
-      user  = "0:0"
-      name  = "infra-db-permfix"
-
-      volumes = [{
-        type      = "bind"
-        source    = synology_filestation_folder.infra_db_pgdata.real_path
-        target    = "/fix"
-        bind      = { create_host_path = true }
-        read_only = false
-      }]
-
-      entrypoint = ["sh", "-lc"]
-      command = [
-        "chown -R 1001:1001 /fix && chmod 700 /fix && echo OK"
-      ]
-
-      restart = "no"
-
-      healthcheck = {
-        test         = ["CMD-SHELL", "[ -f /bin/true ] || exit 1"]
-        interval     = "10s"
-        timeout      = "2s"
-        retries      = 1
-        start_period = "1s"
-      }
-
-      logging = { driver = "json-file" }
-    }
-
-
-    "postgres" = {
-      image = "bitnamilegacy/postgresql:17.5.0"
-      name  = "infra-db-postgres"
-
-      environment = {
-        POSTGRESQL_USERNAME = var.postgres_user
-        POSTGRESQL_PASSWORD = var.postgres_password
-        TZ                  = "Europe/Paris"
-      }
-
-      volumes = [{
-        type      = "bind"
-        source    = synology_filestation_folder.infra_db_pgdata.real_path
-        target    = "/bitnami/postgresql"
-        bind      = { create_host_path = true }
-        read_only = false
-      }]
-
-      healthcheck = {
-        test         = ["CMD-SHELL", "pg_isready -U ${var.postgres_user} -d postgres -h 127.0.0.1 || exit 1"]
-        interval     = "10s"
-        timeout      = "3s"
-        retries      = 10
-        start_period = "120s"
-      }
-
-
-      restart = "unless-stopped"
-
-      networks = {
-        infra_net = {
-        }
-      }
-
-      logging = { driver = "json-file" }
-      depends_on = {
-        permfix = {
-          condition = "service_completed_successfully"
-        }
-      }
-    }
-
-    "adminer" = {
-      image = "adminer:5.3.0"
-      name  = "infra-db-adminer"
-
-      ports = [{
-        target    = 8080
-        published = var.adminer_published_port
-      }]
-
-      environment = {
-        ADMINER_DEFAULT_SERVER = "postgres"
-      }
-
-      restart = "unless-stopped"
-
-      networks = {
-        infra_net = {}
-        edge_net  = {}
-      }
-
-      depends_on = {
-        "postgres" = {
-          condition = "service_healthy"
-          restart   = true
-        }
-      }
-
-      logging = { driver = "json-file" }
-    }
-  }
-
-  networks = {
-    infra_net = {
-      attachable = true
-      driver     = "bridge"
-      name       = "infra"
-      internal   = true
-    }
-
-    edge_net = {
-      attachable = true
-      driver     = "bridge"
-      name       = "edge"
-      internal   = false
-    }
-  }
+  stack_name                   = "infra-db"
+  project_name                 = "infra-db"
+  remote_dir                   = dirname(synology_filestation_folder.infra_db_pgdata.real_path)
+  ssh_host                     = local.compose_deploy_ssh_host
+  ssh_user                     = local.compose_deploy_ssh_user
+  ssh_port                     = var.deploy_ssh_port
+  ssh_private_key_path         = var.deploy_ssh_private_key_path
+  ssh_strict_host_key_checking = var.deploy_ssh_strict_host_key_checking
+  compose_yaml                 = templatefile("${path.module}/templates/infra-db.compose.yaml.tftpl", {})
+  external_networks = [
+    {
+      name     = "infra"
+      internal = true
+    },
+    {
+      name     = "edge"
+      internal = false
+    },
+  ]
+  env_file = templatefile("${path.module}/templates/infra-db.env.tftpl", {
+    postgres_user          = var.postgres_user
+    postgres_password      = var.postgres_password
+    adminer_published_port = var.adminer_published_port
+  })
 
   depends_on = [
-    synology_filestation_folder.infra_db_pgdata
+    synology_filestation_folder.infra_db_pgdata,
   ]
 }

--- a/justfile
+++ b/justfile
@@ -23,10 +23,12 @@ plan:
 
 # Apply infrastructure changes
 apply:
+    @just ensure-ansible
     @just mask-stream terraform apply --input=false
 
 # Destroy infrastructure
 destroy:
+    @just ensure-ansible
     @terraform destroy --input=false
 
 # Format Terraform code
@@ -40,6 +42,7 @@ check-fmt:
 # Ensure required tools are available for recipes in this Justfile.
 tools:
     @just ensure-mask
+    @just ensure-ansible
 
 [private]
 mask-stream cmd *args: ensure-mask
@@ -48,13 +51,12 @@ mask-stream cmd *args: ensure-mask
 
     work="$(mktemp -d .mask.XXXX)"
     trap 'rm -rf "$work"' EXIT
-    export HOME="$PWD/$work"
 
     while IFS='=' read -r k v; do
-      ./.bin/mask add -- "$v" >/dev/null || true
+      HOME="$PWD/$work" ./.bin/mask add -- "$v" >/dev/null || true
     done < <(env | grep '^TF_VAR_' || true)
 
-    bash -c "{{cmd}} {{args}}" 2>&1 | ./.bin/mask
+    bash -c "{{cmd}} {{args}}" 2>&1 | HOME="$PWD/$work" ./.bin/mask
 
 [private]
 ensure-mask:
@@ -63,3 +65,18 @@ ensure-mask:
     if [ -f "./.bin/mask" ]; then exit 0; fi
     echo "🚀 Installing 'mask' tool..."
     GOBIN="$(pwd)/.bin" go install {{mask_repository}}@{{mask_version}}
+
+[private]
+ensure-ansible:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "🔍 Checking for 'ansible-playbook'..."
+    if ! command -v ansible-playbook >/dev/null 2>&1; then
+      echo "❌ ansible-playbook is required to deploy Compose stacks remotely."
+      echo "   Install Ansible and rerun the command."
+      exit 1
+    fi
+
+    echo "📦 Ensuring required Ansible collections are installed..."
+    ansible-galaxy collection install -r ansible/requirements.yml >/dev/null

--- a/main.tf
+++ b/main.tf
@@ -12,3 +12,8 @@ provider "synology" {
   user     = var.dsm_user
   password = var.dsm_password
 }
+
+locals {
+  compose_deploy_ssh_host = coalesce(var.deploy_ssh_host, var.dsm_host)
+  compose_deploy_ssh_user = coalesce(var.deploy_ssh_user, var.dsm_user)
+}

--- a/modules/compose_stack/main.tf
+++ b/modules/compose_stack/main.tf
@@ -1,0 +1,74 @@
+locals {
+  project_name         = coalesce(var.project_name, var.stack_name)
+  ssh_private_key_path = pathexpand(var.ssh_private_key_path)
+  extra_files = [
+    for path in sort(keys(var.extra_files)) : {
+      path    = path
+      content = var.extra_files[path].content
+      mode    = var.extra_files[path].mode
+    }
+  ]
+
+  deploy_spec = {
+    stack_name        = var.stack_name
+    project_name      = local.project_name
+    remote_dir        = var.remote_dir
+    compose_yaml      = var.compose_yaml
+    env_file          = coalesce(var.env_file, "")
+    extra_files       = local.extra_files
+    external_networks = var.external_networks
+  }
+
+  deploy_spec_b64 = base64encode(jsonencode(local.deploy_spec))
+
+  deploy_playbook  = abspath("${path.root}/ansible/deploy-compose-stack.yml")
+  destroy_playbook = abspath("${path.root}/ansible/destroy-compose-stack.yml")
+
+  extra_files_checksum = join(",", [
+    for path in sort(keys(var.extra_files)) :
+    "${path}:${var.extra_files[path].mode}:${sha256(var.extra_files[path].content)}"
+  ])
+}
+
+resource "terraform_data" "this" {
+  input = {
+    ssh_host                     = var.ssh_host
+    ssh_user                     = var.ssh_user
+    ssh_port                     = var.ssh_port
+    ssh_private_key_path         = local.ssh_private_key_path
+    ssh_strict_host_key_checking = var.ssh_strict_host_key_checking
+    destroy_playbook             = local.destroy_playbook
+    deploy_spec_b64              = local.deploy_spec_b64
+  }
+
+  triggers_replace = [
+    var.stack_name,
+    local.project_name,
+    var.remote_dir,
+    sha256(var.compose_yaml),
+    sha256(jsonencode(var.external_networks)),
+    sha256(coalesce(var.env_file, "")),
+    sha256(local.extra_files_checksum),
+  ]
+
+  provisioner "local-exec" {
+    command = "ansible-playbook -i '${var.ssh_host},' -u '${var.ssh_user}' --private-key '${local.ssh_private_key_path}' -e 'ansible_port=${var.ssh_port}' '${local.deploy_playbook}'"
+
+    environment = {
+      ANSIBLE_HOST_KEY_CHECKING = var.ssh_strict_host_key_checking ? "True" : "False"
+      ANSIBLE_SSH_ARGS          = var.ssh_strict_host_key_checking ? "" : "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+      COMPOSE_STACK_SPEC_B64    = local.deploy_spec_b64
+    }
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "ansible-playbook -i '${self.input.ssh_host},' -u '${self.input.ssh_user}' --private-key '${self.input.ssh_private_key_path}' -e 'ansible_port=${self.input.ssh_port}' '${self.input.destroy_playbook}'"
+
+    environment = {
+      ANSIBLE_HOST_KEY_CHECKING = self.input.ssh_strict_host_key_checking ? "True" : "False"
+      ANSIBLE_SSH_ARGS          = self.input.ssh_strict_host_key_checking ? "" : "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+      COMPOSE_STACK_SPEC_B64    = self.input.deploy_spec_b64
+    }
+  }
+}

--- a/modules/compose_stack/variables.tf
+++ b/modules/compose_stack/variables.tf
@@ -1,0 +1,77 @@
+variable "stack_name" {
+  description = "Logical stack name used for deployment metadata"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Docker Compose project name. Defaults to stack_name when omitted."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "remote_dir" {
+  description = "Absolute directory on the remote host where compose.yaml and related files are stored"
+  type        = string
+}
+
+variable "ssh_host" {
+  description = "SSH host used by Ansible to apply the Compose stack"
+  type        = string
+}
+
+variable "ssh_user" {
+  description = "SSH user used by Ansible to apply the Compose stack"
+  type        = string
+}
+
+variable "ssh_port" {
+  description = "SSH port used by Ansible to apply the Compose stack"
+  type        = number
+  default     = 22
+}
+
+variable "ssh_private_key_path" {
+  description = "Path to the SSH private key used by Ansible to reach the remote host"
+  type        = string
+}
+
+variable "ssh_strict_host_key_checking" {
+  description = "Whether SSH host key checking should remain enabled during Ansible runs"
+  type        = bool
+  default     = false
+}
+
+variable "compose_yaml" {
+  description = "Rendered compose.yaml content for the stack"
+  type        = string
+}
+
+variable "external_networks" {
+  description = "Docker networks that must exist before applying the Compose stack"
+  type = list(object({
+    name     = string
+    internal = optional(bool, false)
+  }))
+  default  = []
+  nullable = false
+}
+
+variable "env_file" {
+  description = "Rendered .env content for the stack"
+  type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+variable "extra_files" {
+  description = "Additional files written next to compose.yaml before applying the stack"
+  type = map(object({
+    content = string
+    mode    = optional(string, "0644")
+  }))
+  default   = {}
+  nullable  = false
+  sensitive = true
+}

--- a/modules/zeroclaw/main.tf
+++ b/modules/zeroclaw/main.tf
@@ -19,66 +19,34 @@ resource "synology_filestation_folder" "data" {
   }
 }
 
-resource "synology_container_project" "this" {
-  name       = local.project_name
-  run        = true
-  share_path = "${var.projects_root}/${local.project_name}"
+module "compose_stack" {
+  source = "../compose_stack"
 
-  services = {
-    zeroclaw = {
-      image = var.image
-      name  = local.project_name
-
-      command = [
-        "zeroclaw",
-        "daemon",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        "42617",
-      ]
-
-      ports = [{
-        target    = 42617
-        published = var.published_port
-      }]
-
-      volumes = [{
-        type      = "bind"
-        source    = "./data"
-        target    = "/root/.zeroclaw"
-        bind      = { create_host_path = true }
-        read_only = false
-      }]
-
-      healthcheck = {
-        test         = ["CMD", "zeroclaw", "status", "--format=exit-code"]
-        interval     = "60s"
-        timeout      = "10s"
-        retries      = 3
-        start_period = "10s"
-      }
-
-      restart = "unless-stopped"
-
-      networks = {
-        edge_net = {}
-      }
-
-      logging = { driver = "json-file" }
-    }
-  }
-
-  networks = {
-    edge_net = {
-      attachable = true
-      driver     = "bridge"
-      name       = var.edge_network_name
-      external   = true
-    }
-  }
+  stack_name                   = local.project_name
+  project_name                 = local.project_name
+  remote_dir                   = dirname(synology_filestation_folder.data.real_path)
+  ssh_host                     = var.deploy_ssh_host
+  ssh_user                     = var.deploy_ssh_user
+  ssh_port                     = var.deploy_ssh_port
+  ssh_private_key_path         = var.deploy_ssh_private_key_path
+  ssh_strict_host_key_checking = var.deploy_ssh_strict_host_key_checking
+  compose_yaml = templatefile("${path.module}/templates/compose.yaml.tftpl", {
+    project_name      = local.project_name
+    edge_network_name = var.edge_network_name
+    image             = var.image
+    published_port    = var.published_port
+  })
+  external_networks = [
+    {
+      name     = var.edge_network_name
+      internal = false
+    },
+  ]
+  env_file = templatefile("${path.module}/templates/env.tftpl", {
+    published_port = var.published_port
+  })
 
   depends_on = [
-    synology_filestation_folder.data
+    synology_filestation_folder.data,
   ]
 }

--- a/modules/zeroclaw/templates/compose.yaml.tftpl
+++ b/modules/zeroclaw/templates/compose.yaml.tftpl
@@ -1,0 +1,35 @@
+services:
+  zeroclaw:
+    image: ${image}
+    container_name: ${project_name}
+    command:
+      - zeroclaw
+      - daemon
+      - --host
+      - 0.0.0.0
+      - --port
+      - "42617"
+    ports:
+      - "$${ZEROCLAW_PUBLISHED_PORT}:42617"
+    volumes:
+      - ./data:/root/.zeroclaw
+    healthcheck:
+      test:
+        - CMD
+        - zeroclaw
+        - status
+        - --format=exit-code
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - edge_net
+    logging:
+      driver: json-file
+
+networks:
+  edge_net:
+    external: true
+    name: ${edge_network_name}

--- a/modules/zeroclaw/templates/env.tftpl
+++ b/modules/zeroclaw/templates/env.tftpl
@@ -1,0 +1,1 @@
+ZEROCLAW_PUBLISHED_PORT=${published_port}

--- a/modules/zeroclaw/variables.tf
+++ b/modules/zeroclaw/variables.tf
@@ -29,3 +29,30 @@ variable "edge_network_name" {
   type        = string
   default     = "edge"
 }
+
+variable "deploy_ssh_host" {
+  description = "SSH host used by Ansible to apply rendered Compose stacks"
+  type        = string
+}
+
+variable "deploy_ssh_user" {
+  description = "SSH user used by Ansible to apply rendered Compose stacks"
+  type        = string
+}
+
+variable "deploy_ssh_port" {
+  description = "SSH port used by Ansible to apply rendered Compose stacks"
+  type        = number
+  default     = 22
+}
+
+variable "deploy_ssh_private_key_path" {
+  description = "Path to the SSH private key used by Ansible to reach the remote host"
+  type        = string
+}
+
+variable "deploy_ssh_strict_host_key_checking" {
+  description = "Whether SSH host key checking should remain enabled during Ansible runs"
+  type        = bool
+  default     = false
+}

--- a/n8n.tf
+++ b/n8n.tf
@@ -7,212 +7,52 @@ resource "synology_filestation_folder" "n8n_data" {
   }
 }
 
-resource "synology_container_project" "n8n" {
-  name       = "n8n"
-  run        = true
-  share_path = "${var.dsm_volume_projects}/n8n"
+module "n8n" {
+  source = "./modules/compose_stack"
 
-  services = {
-    permfix = {
-      image = "alpine:3.22"
-      user  = "0:0"
-      name  = "n8n-permfix"
-
-      volumes = [{
-        type      = "bind"
-        source    = synology_filestation_folder.n8n_data.real_path
-        target    = "/fix"
-        bind      = { create_host_path = true }
-        read_only = false
-      }]
-
-      entrypoint = ["sh", "-lc"]
-      command = [
-        "chown -R 1000:1000 /fix && chmod 755 /fix && echo OK"
-      ]
-
-      restart = "no"
-
-      healthcheck = {
-        test         = ["CMD-SHELL", "[ -f /bin/true ] || exit 1"]
-        interval     = "10s"
-        timeout      = "2s"
-        retries      = 1
-        start_period = "1s"
-      }
-
-      logging = { driver = "json-file" }
-    }
-
-    db_bootstrap = {
-      image = "postgres:17-alpine"
-      name  = "n8n-db-bootstrap"
-
-      environment = {
-        PGPASSWORD = var.postgres_password
-        TZ         = "Europe/Paris"
-      }
-
-      configs = [
-        { source = "n8n-bootstrap", target = "/bootstrap/init.sql", uid = 0, gid = 0, mode = "0440" },
-      ]
-
-      entrypoint = ["sh", "-lc"]
-      command = [<<-EOC
-        set -e
-        echo "🚀 Starting n8n database bootstrap..."
-
-        echo "Waiting for PostgreSQL to be ready..."
-        until pg_isready -h postgres -U ${var.postgres_user}; do
-          echo "🙅 PostgreSQL not ready, retrying in 2s..."
-          sleep 2
-        done
-        echo "✅ PostgreSQL is ready!"
-
-        echo "Initializing n8n database and user..."
-        psql -v ON_ERROR_STOP=1 \
-             -h postgres -U ${var.postgres_user} -d postgres \
-             -f /bootstrap/init.sql
-
-        echo "✅ n8n database initialization completed successfully"
-
-        touch /.bootstrap_completed
-        echo "🎉 Bootstrap process finished!"
-      EOC
-      ]
-
-      restart = "no"
-
-      healthcheck = {
-        test         = ["CMD-SHELL", "[ -f /.bootstrap_completed ] || exit 1"]
-        interval     = "5s"
-        timeout      = "3s"
-        retries      = 1
-        start_period = "1s"
-      }
-
-      networks = {
-        n8n_infra_net = {}
-      }
-
-      logging = { driver = "json-file" }
-    }
-
-    "n8n" = {
-      image = "n8nio/n8n:2.1.5-amd64"
-      name  = "n8n-n8n"
-
-      ports = [{
-        target    = 5678
-        published = var.n8n_published_port
-      }]
-
-      environment = {
-        N8N_HOST                            = var.n8n_host
-        N8N_PORT                            = "5678"
-        N8N_PROTOCOL                        = "http"
-        N8N_ENCRYPTION_KEY                  = var.n8n_encryption_key
-        WEBHOOK_URL                         = var.n8n_webhook_url
-        GENERIC_TIMEZONE                    = "Europe/Paris"
-        N8N_LOG_LEVEL                       = "info"
-        N8N_LOG_OUTPUT                      = "console"
-        N8N_DISABLE_PRODUCTION_MAIN_PROCESS = "false"
-        N8N_METRICS                         = "false"
-
-        DB_TYPE                = "postgresdb"
-        DB_POSTGRESDB_HOST     = "postgres"
-        DB_POSTGRESDB_PORT     = "5432"
-        DB_POSTGRESDB_DATABASE = var.n8n_postgres_db
-        DB_POSTGRESDB_USER     = var.n8n_postgres_user
-        DB_POSTGRESDB_PASSWORD = var.n8n_postgres_password
-        DB_POSTGRESDB_SCHEMA   = "public"
-      }
-
-      volumes = [{
-        type      = "bind"
-        source    = synology_filestation_folder.n8n_data.real_path
-        target    = "/home/node/.n8n"
-        bind      = { create_host_path = true }
-        read_only = false
-      }]
-
-      healthcheck = {
-        test         = ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:5678/healthz || exit 1"]
-        interval     = "30s"
-        timeout      = "10s"
-        retries      = 5
-        start_period = "60s"
-      }
-
-      restart = "unless-stopped"
-
-      networks = {
-        n8n_infra_net = {}
-        n8n_edge_net  = {}
-      }
-
-      depends_on = {
-        permfix      = { condition = "service_completed_successfully" }
-        db_bootstrap = { condition = "service_completed_successfully" }
-      }
-
-      logging = { driver = "json-file" }
-    }
-  }
-
-  configs = {
-    "n8n-bootstrap" = {
-      name    = "n8n-bootstrap.sql"
-      content = <<-SQL
-        -- n8n Database Bootstrap Script
-        -- Initializes user, database and permissions for n8n application
-
-        -- Create user with conditional logic (idempotent)
-        DO $$
-        BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${replace(var.n8n_postgres_user, "'", "''")}') THEN
-                CREATE ROLE "${replace(var.n8n_postgres_user, "'", "''")}" LOGIN PASSWORD '${replace(var.n8n_postgres_password, "'", "''")}';
-                RAISE NOTICE 'Created user: ${replace(var.n8n_postgres_user, "'", "''")}';
-            ELSE
-                ALTER ROLE "${replace(var.n8n_postgres_user, "'", "''")}" WITH LOGIN PASSWORD '${replace(var.n8n_postgres_password, "'", "''")}';
-                RAISE NOTICE 'Updated password for user: ${replace(var.n8n_postgres_user, "'", "''")}';
-            END IF;
-        END
-        $$ LANGUAGE plpgsql;
-
-        -- Create database (outside transaction, with IF NOT EXISTS)
-        \echo 'Creating database if it does not exist...'
-        SELECT 'CREATE DATABASE "${replace(var.n8n_postgres_db, "'", "''")}" OWNER "${replace(var.n8n_postgres_user, "'", "''")}"'
-        WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${replace(var.n8n_postgres_db, "'", "''")}') \gexec
-
-        -- Ensure ownership and privileges (idempotent)
-        \echo 'Setting ownership and privileges...'
-        ALTER DATABASE "${replace(var.n8n_postgres_db, "'", "''")}" OWNER TO "${replace(var.n8n_postgres_user, "'", "''")}";
-        GRANT ALL PRIVILEGES ON DATABASE "${replace(var.n8n_postgres_db, "'", "''")}" TO "${replace(var.n8n_postgres_user, "'", "''")}";
-
-        \echo '✅ Bootstrap completed successfully!'
-      SQL
-    }
-  }
-
-  networks = {
-    n8n_infra_net = {
-      attachable = true
-      driver     = "bridge"
-      name       = "infra"
-      external   = true
-    }
-
-    n8n_edge_net = {
-      attachable = true
-      driver     = "bridge"
-      name       = "edge"
-      external   = true
+  stack_name                   = "n8n"
+  project_name                 = "n8n"
+  remote_dir                   = dirname(synology_filestation_folder.n8n_data.real_path)
+  ssh_host                     = local.compose_deploy_ssh_host
+  ssh_user                     = local.compose_deploy_ssh_user
+  ssh_port                     = var.deploy_ssh_port
+  ssh_private_key_path         = var.deploy_ssh_private_key_path
+  ssh_strict_host_key_checking = var.deploy_ssh_strict_host_key_checking
+  compose_yaml                 = templatefile("${path.module}/templates/n8n.compose.yaml.tftpl", {})
+  external_networks = [
+    {
+      name     = "infra"
+      internal = true
+    },
+    {
+      name     = "edge"
+      internal = false
+    },
+  ]
+  env_file = templatefile("${path.module}/templates/n8n.env.tftpl", {
+    postgres_user         = var.postgres_user
+    postgres_password     = var.postgres_password
+    n8n_published_port    = var.n8n_published_port
+    n8n_host              = var.n8n_host
+    n8n_webhook_url       = var.n8n_webhook_url
+    n8n_encryption_key    = var.n8n_encryption_key
+    n8n_postgres_db       = var.n8n_postgres_db
+    n8n_postgres_user     = var.n8n_postgres_user
+    n8n_postgres_password = var.n8n_postgres_password
+  })
+  extra_files = {
+    "init.sql" = {
+      content = templatefile("${path.module}/templates/n8n.init.sql.tftpl", {
+        n8n_postgres_db       = var.n8n_postgres_db
+        n8n_postgres_user     = var.n8n_postgres_user
+        n8n_postgres_password = var.n8n_postgres_password
+      })
+      mode = "0644"
     }
   }
 
   depends_on = [
     synology_filestation_folder.n8n_data,
-    synology_container_project.infra_db
+    module.infra_db,
   ]
 }

--- a/templates/bobine.compose.yaml.tftpl
+++ b/templates/bobine.compose.yaml.tftpl
@@ -1,0 +1,80 @@
+services:
+  permfix:
+    image: alpine:3.22
+    container_name: bobine-permfix
+    user: "0:0"
+    volumes:
+      - ./local:/fix
+    entrypoint:
+      - sh
+      - -lc
+    command:
+      - chown -R 1000:1000 /fix && chmod 755 /fix && echo OK
+    restart: "no"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "[ -f /bin/true ] || exit 1"
+      interval: 10s
+      timeout: 2s
+      retries: 1
+      start_period: 1s
+    logging:
+      driver: json-file
+
+  bobine:
+    image: denoland/deno:debian-2.6.3
+    container_name: bobine-bobine
+    user: "1000:1000"
+    ports:
+      - "$${BOBINE_PUBLISHED_PORT}:8080"
+    volumes:
+      - ./local:/app/local
+    environment:
+      DATABASE_PATH: ./local/database.db
+      SCRIPTS_PATH: ./local/scripts
+      ED25519_PRIVATE_KEY_HEX: $${BOBINE_ED25519_PRIVATE_KEY_HEX}
+      ED25519_PUBLIC_KEY_HEX: $${BOBINE_ED25519_PUBLIC_KEY_HEX}
+    entrypoint:
+      - sh
+      - -lc
+    command:
+      - |-
+        set -eu
+        export DENO_DIR="/app/local/deno-dir"
+        export DENO_INSTALL_ROOT="/app/local/deno-install"
+        export PATH="$$DENO_INSTALL_ROOT/bin:$$PATH"
+        mkdir -p "$$DENO_DIR" "$$DENO_INSTALL_ROOT" /app/local/scripts /tmp/bobine
+        if ! command -v bobine >/dev/null 2>&1; then
+          deno install --root "$$DENO_INSTALL_ROOT" -g -f -A npm:@hazae41/bobine
+        fi
+        printf "DATABASE_PATH=%s\nSCRIPTS_PATH=%s\nED25519_PRIVATE_KEY_HEX=%s\nED25519_PUBLIC_KEY_HEX=%s\n" \
+          "$$DATABASE_PATH" \
+          "$$SCRIPTS_PATH" \
+          "$$ED25519_PRIVATE_KEY_HEX" \
+          "$$ED25519_PUBLIC_KEY_HEX" \
+          > /tmp/bobine/.env
+        cd /app
+        exec bobine serve --env=/tmp/bobine/.env --port=8080 --dev
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          deno eval "const socket = await Deno.connect({ hostname: '127.0.0.1', port: 8080 }); socket.close();"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - edge_net
+    depends_on:
+      permfix:
+        condition: service_completed_successfully
+    logging:
+      driver: json-file
+
+networks:
+  edge_net:
+    external: true
+    name: edge

--- a/templates/bobine.env.tftpl
+++ b/templates/bobine.env.tftpl
@@ -1,0 +1,3 @@
+BOBINE_PUBLISHED_PORT=${bobine_published_port}
+BOBINE_ED25519_PRIVATE_KEY_HEX=${bobine_ed25519_private_key_hex}
+BOBINE_ED25519_PUBLIC_KEY_HEX=${bobine_ed25519_public_key_hex}

--- a/templates/infra-db.compose.yaml.tftpl
+++ b/templates/infra-db.compose.yaml.tftpl
@@ -1,0 +1,75 @@
+services:
+  permfix:
+    image: alpine:3.22
+    container_name: infra-db-permfix
+    user: "0:0"
+    volumes:
+      - ./postgres-data:/fix
+    entrypoint:
+      - sh
+      - -lc
+    command:
+      - chown -R 1001:1001 /fix && chmod 700 /fix && echo OK
+    restart: "no"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "[ -f /bin/true ] || exit 1"
+      interval: 10s
+      timeout: 2s
+      retries: 1
+      start_period: 1s
+    logging:
+      driver: json-file
+
+  postgres:
+    image: bitnamilegacy/postgresql:17.5.0
+    container_name: infra-db-postgres
+    environment:
+      POSTGRESQL_USERNAME: $${POSTGRES_USER}
+      POSTGRESQL_PASSWORD: $${POSTGRES_PASSWORD}
+      TZ: Europe/Paris
+    volumes:
+      - ./postgres-data:/bitnami/postgresql
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U $${POSTGRES_USER} -d postgres -h 127.0.0.1 || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 120s
+    restart: unless-stopped
+    networks:
+      - infra_net
+    depends_on:
+      permfix:
+        condition: service_completed_successfully
+    logging:
+      driver: json-file
+
+  adminer:
+    image: adminer:5.3.0
+    container_name: infra-db-adminer
+    ports:
+      - "$${ADMINER_PUBLISHED_PORT}:8080"
+    environment:
+      ADMINER_DEFAULT_SERVER: postgres
+    restart: unless-stopped
+    networks:
+      - infra_net
+      - edge_net
+    depends_on:
+      postgres:
+        condition: service_healthy
+    logging:
+      driver: json-file
+
+networks:
+  infra_net:
+    external: true
+    name: infra
+
+  edge_net:
+    external: true
+    name: edge

--- a/templates/infra-db.env.tftpl
+++ b/templates/infra-db.env.tftpl
@@ -1,0 +1,3 @@
+POSTGRES_USER=${postgres_user}
+POSTGRES_PASSWORD=${postgres_password}
+ADMINER_PUBLISHED_PORT=${adminer_published_port}

--- a/templates/n8n.compose.yaml.tftpl
+++ b/templates/n8n.compose.yaml.tftpl
@@ -1,0 +1,119 @@
+services:
+  permfix:
+    image: alpine:3.22
+    container_name: n8n-permfix
+    user: "0:0"
+    volumes:
+      - ./data:/fix
+    entrypoint:
+      - sh
+      - -lc
+    command:
+      - chown -R 1000:1000 /fix && chmod 755 /fix && echo OK
+    restart: "no"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "[ -f /bin/true ] || exit 1"
+      interval: 10s
+      timeout: 2s
+      retries: 1
+      start_period: 1s
+    logging:
+      driver: json-file
+
+  db_bootstrap:
+    image: postgres:17-alpine
+    container_name: n8n-db-bootstrap
+    environment:
+      PGPASSWORD: $${POSTGRES_PASSWORD}
+      TZ: Europe/Paris
+    volumes:
+      - ./init.sql:/bootstrap/init.sql:ro
+    entrypoint:
+      - sh
+      - -lc
+    command:
+      - |-
+        set -e
+        echo "Starting n8n database bootstrap..."
+        echo "Waiting for PostgreSQL to be ready..."
+        until pg_isready -h postgres -U $${POSTGRES_USER}; do
+          echo "PostgreSQL not ready, retrying in 2s..."
+          sleep 2
+        done
+        echo "PostgreSQL is ready!"
+        echo "Initializing n8n database and user..."
+        psql -v ON_ERROR_STOP=1 \
+             -h postgres -U $${POSTGRES_USER} -d postgres \
+             -f /bootstrap/init.sql
+        echo "n8n database initialization completed successfully"
+        touch /.bootstrap_completed
+        echo "Bootstrap process finished!"
+    restart: "no"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "[ -f /.bootstrap_completed ] || exit 1"
+      interval: 5s
+      timeout: 3s
+      retries: 1
+      start_period: 1s
+    networks:
+      - infra_net
+    logging:
+      driver: json-file
+
+  n8n:
+    image: n8nio/n8n:2.1.5-amd64
+    container_name: n8n-n8n
+    ports:
+      - "$${N8N_PUBLISHED_PORT}:5678"
+    environment:
+      N8N_HOST: $${N8N_HOST}
+      N8N_PORT: "5678"
+      N8N_PROTOCOL: http
+      N8N_ENCRYPTION_KEY: $${N8N_ENCRYPTION_KEY}
+      WEBHOOK_URL: $${N8N_WEBHOOK_URL}
+      GENERIC_TIMEZONE: Europe/Paris
+      N8N_LOG_LEVEL: info
+      N8N_LOG_OUTPUT: console
+      N8N_DISABLE_PRODUCTION_MAIN_PROCESS: "false"
+      N8N_METRICS: "false"
+      DB_TYPE: postgresdb
+      DB_POSTGRESDB_HOST: postgres
+      DB_POSTGRESDB_PORT: "5432"
+      DB_POSTGRESDB_DATABASE: $${N8N_POSTGRES_DB}
+      DB_POSTGRESDB_USER: $${N8N_POSTGRES_USER}
+      DB_POSTGRESDB_PASSWORD: $${N8N_POSTGRES_PASSWORD}
+      DB_POSTGRESDB_SCHEMA: public
+    volumes:
+      - ./data:/home/node/.n8n
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - wget --no-verbose --tries=1 --spider http://localhost:5678/healthz || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    restart: unless-stopped
+    networks:
+      - infra_net
+      - edge_net
+    depends_on:
+      permfix:
+        condition: service_completed_successfully
+      db_bootstrap:
+        condition: service_completed_successfully
+    logging:
+      driver: json-file
+
+networks:
+  infra_net:
+    external: true
+    name: infra
+
+  edge_net:
+    external: true
+    name: edge

--- a/templates/n8n.env.tftpl
+++ b/templates/n8n.env.tftpl
@@ -1,0 +1,9 @@
+POSTGRES_USER=${postgres_user}
+POSTGRES_PASSWORD=${postgres_password}
+N8N_PUBLISHED_PORT=${n8n_published_port}
+N8N_HOST=${n8n_host}
+N8N_WEBHOOK_URL=${n8n_webhook_url}
+N8N_ENCRYPTION_KEY=${n8n_encryption_key}
+N8N_POSTGRES_DB=${n8n_postgres_db}
+N8N_POSTGRES_USER=${n8n_postgres_user}
+N8N_POSTGRES_PASSWORD=${n8n_postgres_password}

--- a/templates/n8n.init.sql.tftpl
+++ b/templates/n8n.init.sql.tftpl
@@ -1,0 +1,24 @@
+-- n8n Database Bootstrap Script
+-- Initializes user, database and permissions for n8n application
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${replace(n8n_postgres_user, "'", "''")}') THEN
+        CREATE ROLE "${replace(n8n_postgres_user, "'", "''")}" LOGIN PASSWORD '${replace(n8n_postgres_password, "'", "''")}';
+        RAISE NOTICE 'Created user: ${replace(n8n_postgres_user, "'", "''")}';
+    ELSE
+        ALTER ROLE "${replace(n8n_postgres_user, "'", "''")}" WITH LOGIN PASSWORD '${replace(n8n_postgres_password, "'", "''")}';
+        RAISE NOTICE 'Updated password for user: ${replace(n8n_postgres_user, "'", "''")}';
+    END IF;
+END
+$$ LANGUAGE plpgsql;
+
+\echo 'Creating database if it does not exist...'
+SELECT 'CREATE DATABASE "${replace(n8n_postgres_db, "'", "''")}" OWNER "${replace(n8n_postgres_user, "'", "''")}"'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${replace(n8n_postgres_db, "'", "''")}') \gexec
+
+\echo 'Setting ownership and privileges...'
+ALTER DATABASE "${replace(n8n_postgres_db, "'", "''")}" OWNER TO "${replace(n8n_postgres_user, "'", "''")}";
+GRANT ALL PRIVILEGES ON DATABASE "${replace(n8n_postgres_db, "'", "''")}" TO "${replace(n8n_postgres_user, "'", "''")}";
+
+\echo 'Bootstrap completed successfully!'

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,36 @@ variable "dsm_volume_projects" {
   default     = "/projects"
   sensitive   = false
 }
+
+variable "deploy_ssh_host" {
+  description = "SSH host used by Ansible to apply rendered Compose stacks on the Synology NAS"
+  type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+variable "deploy_ssh_user" {
+  description = "SSH user used by Ansible to apply rendered Compose stacks on the Synology NAS"
+  type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+variable "deploy_ssh_port" {
+  description = "SSH port used by Ansible to apply rendered Compose stacks on the Synology NAS"
+  type        = number
+  default     = 22
+}
+
+variable "deploy_ssh_private_key_path" {
+  description = "Path to the SSH private key used by Ansible to reach the Synology NAS"
+  type        = string
+}
+
+variable "deploy_ssh_strict_host_key_checking" {
+  description = "Whether Ansible should enforce SSH host key checking when deploying Compose stacks"
+  type        = bool
+  default     = false
+}

--- a/zeroclaw.tf
+++ b/zeroclaw.tf
@@ -1,17 +1,27 @@
 module "zeroclaw_cyrus" {
   source = "./modules/zeroclaw"
 
-  instance_name  = "cyrus"
-  projects_root  = var.dsm_volume_projects
-  published_port = 42617
-  image          = var.zeroclaw_image
+  instance_name                       = "cyrus"
+  projects_root                       = var.dsm_volume_projects
+  published_port                      = 42617
+  image                               = var.zeroclaw_image
+  deploy_ssh_host                     = local.compose_deploy_ssh_host
+  deploy_ssh_user                     = local.compose_deploy_ssh_user
+  deploy_ssh_port                     = var.deploy_ssh_port
+  deploy_ssh_private_key_path         = var.deploy_ssh_private_key_path
+  deploy_ssh_strict_host_key_checking = var.deploy_ssh_strict_host_key_checking
 }
 
 module "zeroclaw_lior" {
   source = "./modules/zeroclaw"
 
-  instance_name  = "lior"
-  projects_root  = var.dsm_volume_projects
-  published_port = 42618
-  image          = var.zeroclaw_image
+  instance_name                       = "lior"
+  projects_root                       = var.dsm_volume_projects
+  published_port                      = 42618
+  image                               = var.zeroclaw_image
+  deploy_ssh_host                     = local.compose_deploy_ssh_host
+  deploy_ssh_user                     = local.compose_deploy_ssh_user
+  deploy_ssh_port                     = var.deploy_ssh_port
+  deploy_ssh_private_key_path         = var.deploy_ssh_private_key_path
+  deploy_ssh_strict_host_key_checking = var.deploy_ssh_strict_host_key_checking
 }


### PR DESCRIPTION
Time to move on. The [Synology Terraform provider](https://registry.terraform.io/providers/synology-community/synology/latest/docs) made Container Manager automation far more cursed than necessary, so the runtime now shifts to Ansible-managed Docker Compose stacks on my NAS, while keeping the repo GitOps-friendly and the Synology-specific bits mostly limited to folder provisioning.

Let's see where this goes...